### PR TITLE
Use a per-tile rasterized solution for aggregating analysis results

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,8 @@ scalaVersion := "2.12.12"
 
 libraryDependencies ++= Seq(
   "com.monovore" %% "decline" % "1.2.0",
-  "org.locationtech.rasterframes" %% "rasterframes" % "0.10.1-SNAPSHOT",
-  "org.locationtech.rasterframes" %% "rasterframes-datasource" % "0.10.1-SNAPSHOT",
+  "org.locationtech.rasterframes" %% "rasterframes" % "0.10.1",
+  "org.locationtech.rasterframes" %% "rasterframes-datasource" % "0.10.1",
   "org.scalanlp" %% "breeze" % "0.13.2",
   "org.apache.spark" %% "spark-core" % "3.1.2" % Compile,
   "org.apache.spark" %% "spark-sql" % "3.1.2" % Compile,

--- a/src/main/scala/org/globalforestwatch/Analysis.scala
+++ b/src/main/scala/org/globalforestwatch/Analysis.scala
@@ -5,6 +5,7 @@ import geotrellis.raster.{Raster, Tile}
 import geotrellis.raster.summary.GridVisitor
 import geotrellis.raster.summary.polygonal.PolygonalSummary
 import geotrellis.vector.Geometry
+import org.apache.log4j.Logger
 import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.functions.{col, udaf, udf, when}
 import org.globalforestwatch.grids._
@@ -36,6 +37,8 @@ abstract class HistogramAnalysis(override val name: String) extends Analysis(nam
 }
 
 object Analysis {
+  val logger = Logger.getLogger(getClass.getName)
+
   val aggByYear = udaf(LossYearAgg)
   val aggHist = udaf(HistogramAgg)
 
@@ -86,6 +89,7 @@ object Analysis {
     yearTile: Tile,
     criterionTile: Tile
   ): Array[Double] = {
+    logger.warn(s"Rasterizing for ${key}; tile is ${yearTile.cols}×${yearTile.rows}")
     val trans = TenByTen30mGrid.segmentTileGrid.mapTransform
     val extent = trans.keyToExtent(key)
     val year = Raster(yearTile, extent)

--- a/src/main/scala/org/globalforestwatch/Analysis.scala
+++ b/src/main/scala/org/globalforestwatch/Analysis.scala
@@ -1,20 +1,47 @@
 package org.globalforestwatch
 
+import geotrellis.layer.SpatialKey
+import geotrellis.raster.{Raster, Tile}
+import geotrellis.raster.summary.GridVisitor
+import geotrellis.raster.summary.polygonal.PolygonalSummary
+import geotrellis.vector.Geometry
 import org.apache.spark.sql.{Column, DataFrame}
-import org.apache.spark.sql.functions.{col, explode, lit, udaf, udf, when}
+import org.apache.spark.sql.functions.{col, udaf, udf, when}
+import org.globalforestwatch.grids._
 import org.globalforestwatch.layers._
+import org.locationtech.rasterframes.{rf_local_greater, rf_local_multiply}
 
 abstract class Analysis(val name: String) {
-  def condition: Column
-  def agg: Column
+  def content: Column
+  def agg: Column =
+    Analysis.aggByYear(TreeCoverLoss.col as "loss_year", col(name) as "area") as name
+}
+
+abstract class HistogramAnalysis(override val name: String) extends Analysis(name) {
+  def content: Column =
+    Analysis.scaleHistogram(
+      histogram,
+      col("area")
+    ) as name
+  def criterionTile: Column
+  def histogram: Column =
+      Analysis.histogramByYear(
+        col("spatial_key"),
+        col("geometry"),
+        TreeCoverLoss.col,
+        criterionTile
+      )
+  override def agg: Column =
+      Analysis.aggHist(col(name)) as name
 }
 
 object Analysis {
   val aggByYear = udaf(LossYearAgg)
+  val aggHist = udaf(HistogramAgg)
 
   def addColumns(df: DataFrame, analyses: List[Analysis]): DataFrame = {
     analyses.foldLeft(df){ (result, analysis) =>
-      result.withColumn(analysis.name, analysis.condition)
+      result.withColumn(analysis.name, analysis.content)
     }
   }
 
@@ -22,34 +49,117 @@ object Analysis {
     analyses.map(a => a.agg as a.name)
   }
 
-  object TreeCoverLossTotalYearly extends Analysis("tree_cover_loss_total_yearly") {
-    def condition: Column =
+  // ---------------------------------------------------- Pixelwise Aggregations
+  object TreeCoverLossTotalYearlyPW extends Analysis("tree_cover_loss_total_yearly") {
+    def content: Column =
       when(TreeCoverLoss.col > 0 && TreeCoverDensityPercent2000.col > 30, col("area")) as name
-    def agg: Column =
-      Analysis.aggByYear(TreeCoverLoss.col as "loss_year", col(name) as "area") as name
   }
 
-  object TreeCoverLoss90Yearly extends Analysis("tree_cover_loss_tcd90_yearly") {
-    def condition: Column =
+  object TreeCoverLoss90YearlyPW extends Analysis("tree_cover_loss_tcd90_yearly") {
+    def content: Column =
       when(TreeCoverLoss.col > 0 && TreeCoverDensityPercent2000.col > 90, col("area")) as name
-    def agg: Column =
-      Analysis.aggByYear(TreeCoverLoss.col as "loss_year", col(name) as "area") as name
   }
 
-  object TreeCoverLossPrimaryForestYearly extends Analysis("tree_cover_loss_primary_forest_yearly") {
-    def condition: Column =
+  object TreeCoverLossPrimaryForestYearlyPW extends Analysis("tree_cover_loss_primary_forest_yearly") {
+    def content: Column =
       when(TreeCoverLoss.col > 0 && PrimaryForest.col > 0, col("area")) as name
-    def agg: Column =
-      Analysis.aggByYear(TreeCoverLoss.col as "loss_year", col(name) as "area") as name
   }
 
-  object TreeCoverLossPeatYearly extends Analysis("tree_cover_loss_peat_yearly") {
-    def condition: Column =
+  object TreeCoverLossPeatYearlyPW extends Analysis("tree_cover_loss_peat_yearly") {
+    def content: Column =
       when(TreeCoverLoss.col > 0 && GFWProPeatlands.col > 0, col("area")) as name
-    def agg: Column =
-      Analysis.aggByYear(TreeCoverLoss.col as "loss_year", col(name) as "area") as name
   }
 
+
+  // --------------------------------------------------- Rasterized Aggregations
+  class HistogramVisitor(val result: Array[Double], key: Tile) extends GridVisitor[Raster[Tile], Array[Double]] {
+    def visit(data: Raster[Tile], c: Int, r: Int) = {
+      val ix = key.get(c, r)
+      if (ix >= 0)
+        result(ix) += data.tile.getDouble(c, r)
+    }
+  }
+
+  def rasterizeToHistogram(
+    key: SpatialKey,
+    geom: Geometry,
+    yearTile: Tile,
+    criterionTile: Tile
+  ): Array[Double] = {
+    val trans = TenByTen30mGrid.segmentTileGrid.mapTransform
+    val extent = trans.keyToExtent(key)
+    val year = Raster(yearTile, extent)
+    val data = Raster(criterionTile, extent)
+    val zero: Array[Double] = Array.fill(32)(0)
+    val visitor = new HistogramVisitor(zero, year.tile)
+    PolygonalSummary(data, geom, visitor, PolygonalSummary.DefaultOptions)
+      .toOption
+      .getOrElse(zero)
+  }
+
+  val histogramByYear = udf { (key, geom, year, criterion) =>
+    rasterizeToHistogram(key, geom, year, criterion)
+  }
+
+  def histogramScale(hist: Array[Double], scale: Double) = hist.map(_ * scale)
+
+  val scaleHistogram = udf { (hist, factor) => histogramScale(hist, factor) }
+
+  object TreeCoverLossTotalYearly extends HistogramAnalysis("tree_cover_loss_total_yearly") {
+    // when(TreeCoverLoss.col > 0 && TreeCoverDensityPercent2000.col > 30, col("area"))
+    def criterionTile: Column = rf_local_multiply(
+      rf_local_greater(
+        TreeCoverLoss.col,
+        0
+      ),
+      rf_local_greater(
+        TreeCoverDensityPercent2000.col,
+        30
+      )
+    )
+  }
+
+  object TreeCoverLoss90Yearly extends HistogramAnalysis("tree_cover_loss_tcd90_yearly") {
+    //   when(TreeCoverLoss.col > 0 && TreeCoverDensityPercent2000.col > 90, col("area"))
+    def criterionTile: Column = rf_local_multiply(
+      rf_local_greater(
+        TreeCoverLoss.col,
+        0
+      ),
+      rf_local_greater(
+        TreeCoverDensityPercent2000.col,
+        90
+      )
+    )
+  }
+
+  object TreeCoverLossPrimaryForestYearly extends HistogramAnalysis("tree_cover_loss_primary_forest_yearly") {
+    // when(TreeCoverLoss.col > 0 && PrimaryForest.col > 0, col("area"))
+    def criterionTile: Column = rf_local_multiply(
+      rf_local_greater(
+        TreeCoverLoss.col,
+        0
+      ),
+      rf_local_greater(
+        PrimaryForest.col,
+        0
+      )
+    )
+  }
+
+  object TreeCoverLossPeatYearly extends HistogramAnalysis("tree_cover_loss_peat_yearly") {
+    // when(TreeCoverLoss.col > 0 && GFWProPeatlands.col > 0, col("area")) as name
+    def criterionTile: Column = rf_local_multiply(
+      rf_local_greater(
+        TreeCoverLoss.col,
+        0
+      ),
+      rf_local_greater(
+        GFWProPeatlands.col,
+        0
+      )
+    )
+  }
   //
   //.withColumn("tree_cover_loss_intact_forest_yearly",
   //  when(
@@ -92,4 +202,3 @@ object Analysis {
 
 
 }
-

--- a/src/main/scala/org/globalforestwatch/ForestChangeDiagnosticRasterized.scala
+++ b/src/main/scala/org/globalforestwatch/ForestChangeDiagnosticRasterized.scala
@@ -79,8 +79,6 @@ object ForestChangeDiagnosticRasterized extends SparkCommand  {
     .withColumnRenamed("key", "location_id")
     .withColumnRenamed("value", "geometry")
 
-    flattened.printSchema
-
     val analyses = List(
       Analysis.TreeCoverLossTotalYearly,
       Analysis.TreeCoverLoss90Yearly,
@@ -89,8 +87,6 @@ object ForestChangeDiagnosticRasterized extends SparkCommand  {
     )
 
     val expanded = Analysis.addColumns(flattened, analyses)
-
-    expanded.printSchema
 
     val df = expanded
       .groupBy(col("list_id"), col("location_id"))

--- a/src/main/scala/org/globalforestwatch/HistogramAgg.scala
+++ b/src/main/scala/org/globalforestwatch/HistogramAgg.scala
@@ -1,0 +1,31 @@
+package org.globalforestwatch
+
+import org.apache.spark.sql.Encoder
+import org.apache.spark.sql.expressions.Aggregator
+import frameless.{TypedEncoder, TypedExpressionEncoder}
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+
+object HistogramAgg extends Aggregator[Array[Double], Array[Double], Map[Int, Double]] {
+  def zero: Array[Double] = Array.fill(32)(0)
+
+  def reduce(buffer: Array[Double], hist: Array[Double]): Array[Double] = {
+    merge(buffer, hist)
+  }
+
+  def merge(b1: Array[Double], b2: Array[Double]): Array[Double] = {
+    for ( i <- 0 until b1.length) {
+      b1(i) = b1(i) + b2(i)
+    }
+    b1
+  }
+
+  implicit def typedEncoder[T: TypedEncoder]: ExpressionEncoder[T] =
+    TypedExpressionEncoder[T].asInstanceOf[ExpressionEncoder[T]]
+
+  // Transform the output of the reduction
+  def finish(reduction: Array[Double]): Map[Int, Double] = reduction.zipWithIndex.map{ case (v, i) => (i, v)}.toMap
+  // Specifies the Encoder for the intermediate value type
+  def bufferEncoder: Encoder[Array[Double]] = typedEncoder[Array[Double]]
+  // Specifies the Encoder for the final output value type
+  def outputEncoder: Encoder[Map[Int, Double]] = typedEncoder[Map[Int, Double]]
+}

--- a/src/main/scala/org/globalforestwatch/Main.scala
+++ b/src/main/scala/org/globalforestwatch/Main.scala
@@ -5,7 +5,7 @@ object Main {
   val name = "gfw-raster-stats"
   val header = "Compute summary statistics for GFW data"
   val main = {
-    ForestChangeDiagnostic.command
+    ForestChangeDiagnostic.command orElse ForestChangeDiagnosticRasterized.command
   }
   val command = Command(name, header, true)(main)
 


### PR DESCRIPTION
The pixelwise calculation of area statistics works out to be too slow.  We're trying to use a rasterizer-based approach to calculate histograms on a per-tile basis which can then be merged.  This PR attempts to accomplish this feat.